### PR TITLE
Infra-commit fix Error not show data in data-table WarehouseIT #50

### DIFF
--- a/src/app/api/assets/excel/import/route.ts
+++ b/src/app/api/assets/excel/import/route.ts
@@ -861,6 +861,15 @@ export async function POST(request: NextRequest) {
               ...warehouseRowData 
             } = row as any;
             
+            // Explicitly set the barcode and sapCode fields
+            if (warehouseBarcodeField !== undefined) {
+              (warehouseRowData as any).barcode = warehouseBarcodeField;
+            }
+            
+            if (warehouseSapCodeField !== undefined) {
+              (warehouseRowData as any).sapCode = warehouseSapCodeField;
+            }
+            
             // If status was not provided in the row data, use a default value
             if (!warehouseStatusField) {
               (warehouseRowData as any).status = 'working';


### PR DESCRIPTION
Issue Analysis
The problem was in the Excel import functionality for Warehouse IT assets. When importing data, the barcode and sapCode fields were not being properly extracted from the imported Excel data and saved to the database.
Root Cause
In the Excel import route (src\app\api\assets\excel\import\route.ts), the destructuring of Warehouse IT data was not correctly handling the barcode and sapCode fields. The fields were being extracted but not properly reassigned to the data object that gets saved to the database.
Solution
I fixed the issue by:
Explicitly setting the barcode and sapCode fields in the Warehouse IT import case:
typescript
// Explicitly set the barcode and sapCode fields
if (warehouseBarcodeField !== undefined) {
  (warehouseRowData as any).barcode = warehouseBarcodeField;
}

if (warehouseSapCodeField !== undefined) {
  (warehouseRowData as any).sapCode = warehouseSapCodeField;
}
Ensuring proper data flow from the Excel import to the database creation.
Verification
The fix ensures that:
Barcode and SAP Code data from Excel imports are properly extracted
The data is correctly saved to the WarehouseIT database table
The data is then correctly retrieved and displayed in the UI
This should resolve the issue where imported Warehouse IT assets were not showing Barcode and SAP Code data in the data table.
Additional Notes
The asset-api-handler was already correctly configured to:
Select the barcode and sapCode fields when fetching WarehouseIT data
Include these fields in the search functionality
Display them in the UI components